### PR TITLE
feat: Implement Quick Back IntelliJ plugin

### DIFF
--- a/src/main/kotlin/com/yourcompany/quickback/BackStateCleaner.kt
+++ b/src/main/kotlin/com/yourcompany/quickback/BackStateCleaner.kt
@@ -1,0 +1,125 @@
+package com.yourcompany.quickback
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileEditor.*
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.diagnostic.Logger
+
+@Service(Service.Level.PROJECT)
+class BackStateCleaner(private val project: Project) :
+    FileEditorManagerListener, DocumentListener, Disposable {
+
+    companion object {
+        private val LOG = Logger.getInstance(BackStateCleaner::class.java)
+    }
+
+    // Stores the file where the "back" icon is currently presumed to be.
+    // This is set by the LineMarkerProvider when it successfully adds a marker.
+    @Volatile
+    var currentTargetFileWithBackIcon: VirtualFile? = null
+
+    init {
+        val messageBusConnection = project.messageBus.connect(this)
+        messageBusConnection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER_TOPIC, this)
+        EditorFactory.getInstance().eventMulticaster.addDocumentListener(this, this)
+        LOG.info("BackStateCleaner initialized and listeners registered for project ${project.name}.")
+    }
+
+    // --- DocumentListener ---
+    override fun beforeDocumentChange(event: DocumentEvent) {
+        // Not used, but required by interface if not using BulkAwareDocumentListener
+    }
+
+    override fun documentChanged(event: DocumentEvent) {
+        val historyService = project.service<NavigationHistoryService>()
+        if (historyService.getLastNavigationSource() == null) return // No active "back" state
+
+        val modifiedDoc = event.document
+        val modifiedVirtualFile = FileDocumentManager.getInstance().getFile(modifiedDoc)
+
+        // If the document that changed is the one where we think the icon is, clear state.
+        if (modifiedVirtualFile != null && modifiedVirtualFile == currentTargetFileWithBackIcon) {
+            LOG.debug("Document changed: ${modifiedVirtualFile.name} (where icon was). Clearing navigation history.")
+            clearHistoryAndRefresh(historyService, modifiedVirtualFile, "document modification in ${modifiedVirtualFile.name}")
+        }
+    }
+
+    // --- FileEditorManagerListener ---
+    override fun fileOpened(source: FileEditorManager, file: VirtualFile) { /* No action needed */ }
+
+    override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
+        val historyService = project.service<NavigationHistoryService>()
+        if (historyService.getLastNavigationSource() == null) return
+
+        // If the file that was closed is where the icon was, clear the state.
+        if (file == currentTargetFileWithBackIcon) {
+            LOG.debug("File closed: ${file.name} (where icon was). Clearing navigation history.")
+            // No need to refresh markers for a closed file. Just clear the state.
+            historyService.clearLastNavigationSource()
+            currentTargetFileWithBackIcon = null // Reset our tracked target
+        }
+    }
+
+    override fun selectionChanged(event: FileEditorManagerEvent) {
+        val historyService = project.service<NavigationHistoryService>()
+        if (historyService.getLastNavigationSource() == null) return
+
+        val newFile = event.newFile
+        val oldFile = event.oldFile // File that lost focus, potentially had the icon
+
+        // If selection changed to a *different* file than where the icon was, clear.
+        if (newFile != null && oldFile != null && newFile != oldFile) {
+            if (oldFile == currentTargetFileWithBackIcon) {
+                LOG.debug("Selection changed from ${oldFile.name} (where icon was) to ${newFile.name}. Clearing history.")
+                clearHistoryAndRefresh(historyService, oldFile, "selection changed from ${oldFile.name} to ${newFile.name}")
+            }
+        } else if (newFile == null && oldFile != null) { // Editor focus lost from oldFile
+             if (oldFile == currentTargetFileWithBackIcon) {
+                LOG.debug("Selection changed from ${oldFile.name} (where icon was) to null. Clearing history.")
+                clearHistoryAndRefresh(historyService, oldFile, "selection changed from ${oldFile.name} to null")
+             }
+        }
+    }
+
+    private fun clearHistoryAndRefresh(
+        historyService: NavigationHistoryService,
+        fileToRefreshMarkersIn: VirtualFile?,
+        reason: String
+    ) {
+        LOG.info("Clearing navigation history due to: $reason. Target file was: ${currentTargetFileWithBackIcon?.name}")
+        val previousTarget = currentTargetFileWithBackIcon
+        historyService.clearLastNavigationSource()
+        currentTargetFileWithBackIcon = null // Reset our tracked target
+
+        val fileToRefresh = fileToRefreshMarkersIn ?: previousTarget
+
+        if (fileToRefresh != null && project.isOpen && !project.isDisposed) {
+            ApplicationManager.getApplication().invokeLater {
+                 if (!project.isDisposed && fileToRefresh.isValid) { // Check file validity
+                    val psiFile = PsiDocumentManager.getInstance(project).findFile(fileToRefresh)
+                    if (psiFile != null) {
+                        LOG.debug("Requesting daemon restart for ${fileToRefresh.name} to remove icon.")
+                        DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
+                    } else {
+                        LOG.warn("Could not find PsiFile for ${fileToRefresh.name} to restart daemon (it might be closed or invalid).")
+                    }
+                 }
+            }
+        } else {
+             LOG.debug("No specific file to refresh or project/file is not in a state to be refreshed.")
+        }
+    }
+
+    override fun dispose() {
+        LOG.info("BackStateCleaner disposed for project ${project.name}.")
+    }
+}

--- a/src/main/kotlin/com/yourcompany/quickback/BackToCallGutterIconRenderer.kt
+++ b/src/main/kotlin/com/yourcompany/quickback/BackToCallGutterIconRenderer.kt
@@ -1,0 +1,59 @@
+package com.yourcompany.quickback
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import javax.swing.Icon
+
+class BackToCallGutterIconRenderer(
+    private val project: Project,
+    private val navigationPoint: NavigationPoint,
+    private val currentElement: PsiElement // Element where the icon is shown
+) : GutterIconRenderer() {
+
+    override fun getIcon(): Icon = AllIcons.Actions.Back // Using a standard IntelliJ icon
+
+    override fun getTooltipText(): String {
+        val sourceFileName = navigationPoint.file.name
+        return if (navigationPoint.sourceFunctionDisplayName != null) {
+            "Go back to call in ${navigationPoint.sourceFunctionDisplayName} (${sourceFileName})"
+        } else {
+            "Go back to ${sourceFileName}"
+        }
+    }
+
+    override fun isNavigateAction(): Boolean = true
+
+    override fun getClickAction(): com.intellij.openapi.actionSystem.AnAction? {
+        return object : com.intellij.openapi.actionSystem.AnAction() {
+            override fun actionPerformed(e: com.intellij.openapi.actionSystem.AnActionEvent) {
+                ApplicationManager.getApplication().invokeLater {
+                    OpenFileDescriptor(project, navigationPoint.file, navigationPoint.offset).navigate(true)
+                    // Clear the navigation point so the icon disappears after clicking
+                    project.service<NavigationHistoryService>().clearLastNavigationSource()
+                    // Force refresh of line markers for the current file
+                    val currentPsiFile = currentElement.containingFile
+                    if (currentPsiFile != null) {
+                        DaemonCodeAnalyzer.getInstance(project).restart(currentPsiFile)
+                    }
+                }
+            }
+        }
+    }
+
+    // For equality checks, important for LineMarkerProvider updates
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BackToCallGutterIconRenderer) return false
+        return navigationPoint == other.navigationPoint && project == other.project
+    }
+
+    override fun hashCode(): Int {
+        return navigationPoint.hashCode() * 31 + project.hashCode()
+    }
+}

--- a/src/main/kotlin/com/yourcompany/quickback/GoToDefinitionListener.kt
+++ b/src/main/kotlin/com/yourcompany/quickback/GoToDefinitionListener.kt
@@ -1,0 +1,118 @@
+package com.yourcompany.quickback
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.ex.AnActionListener
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.openapi.diagnostic.Logger // Added for logging
+import com.intellij.psi.PsiMethod
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtClassOrObject
+
+
+class GoToDefinitionListener : AnActionListener {
+    companion object {
+        private val LOG = Logger.getInstance(GoToDefinitionListener::class.java) // Added Logger instance
+        private val RELEVANT_ACTION_IDS = setOf(
+            "GotoDeclaration", // Standard go to declaration
+            "GotoDeclarationOnly",
+            "GotoTypeDeclaration",
+            "GotoImplementation",
+            // Potentially others like "QuickDefinition" if we want to handle previews,
+            // but that might make the "back" button appear too often.
+        )
+    }
+
+    override fun beforeActionPerformed(action: AnAction, dataContext: DataContext, event: AnActionEvent) {
+        val project = event.project ?: return
+        val actionId = ActionManager.getInstance().getId(action)
+
+        if (actionId in RELEVANT_ACTION_IDS) {
+            LOG.debug("Action performed: $actionId") // Log action
+            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
+            val currentFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document)?.virtualFile ?: return
+
+            // Ignore navigation from library sources or SDKs for now, focus on project files
+            // This check can be refined or made configurable
+            if (ProjectRootManager.getInstance(project).fileIndex.isInLibrarySource(currentFile) ||
+                ProjectRootManager.getInstance(project).fileIndex.isInLibraryClasses(currentFile)) {
+                LOG.debug("Skipping navigation from library file: ${currentFile.path}")
+                // Clear any previous point so the back button doesn't show up if we jump from lib to project code
+                project.service<NavigationHistoryService>().clearLastNavigationSource()
+                return
+            }
+
+            val offset = editor.caretModel.offset
+            val sourceFunctionName = findEnclosingFunctionName(project, editor, offset)
+
+            LOG.debug("Storing navigation source: ${currentFile.name}, offset $offset, function: $sourceFunctionName")
+            val navigationPoint = NavigationPoint(currentFile, offset, sourceFunctionName)
+            project.service<NavigationHistoryService>().setLastNavigationSource(navigationPoint)
+        }
+    }
+
+    private fun findEnclosingFunctionName(project: Project, editor: Editor, offset: Int): String? {
+        var name: String? = null
+        ApplicationManager.getApplication().runReadAction {
+            val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return@runReadAction
+            var currentElement = psiFile.findElementAt(offset)
+            while (currentElement != null) {
+                if (currentElement is PsiMethod) {
+                    name = currentElement.name
+                    break
+                }
+                if (currentElement is KtNamedFunction) {
+                    name = currentElement.name
+                    break
+                }
+                // As a fallback, if we are inside a class, use class name.
+                // This could be expanded. The original request focused on "function_A".
+                if (currentElement is com.intellij.psi.PsiClass && name == null) {
+                     name = currentElement.name
+                }
+                 if (currentElement is org.jetbrains.kotlin.psi.KtClassOrObject && name == null) {
+                    name = currentElement.name
+                }
+                currentElement = currentElement.parent
+            }
+        }
+        return name
+    }
+
+    override fun afterActionPerformed(action: AnAction, dataContext: DataContext, event: AnActionEvent) {
+        // Potentially, if the navigation failed or didn't change the location,
+        // we might want to clear the lastNavigationSource here.
+        // For now, we rely on the LineMarkerProvider to only show the icon if navigation actually happened
+        // to a *different* location.
+        val project = event.project
+        val actionId = ActionManager.getInstance().getId(action)
+        if (project != null && actionId in RELEVANT_ACTION_IDS) {
+            LOG.debug("After action: $actionId. Current editor will be checked by LineMarkerProvider.")
+            // Force a refresh of code insight features, including line markers
+            // This helps if the navigation lands in the same editor but different location.
+             ApplicationManager.getApplication().invokeLater {
+                if (!project.isDisposed) {
+                    PsiDocumentManager.getInstance(project).commitAllDocuments() // Ensure PSI is up-to-date
+                    val currentEditor = FileEditorManager.getInstance(project).selectedTextEditor
+                    if (currentEditor != null) {
+                        // This is a bit of a heavy hammer, but ensures line markers are re-evaluated.
+                        // com.intellij.codeInsight.daemon.DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
+                        // For now, let's rely on the focus change or FileEditorManagerListener to trigger updates.
+                        // If issues arise, we can add more explicit refresh calls.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yourcompany/quickback/NavigationHistoryService.kt
+++ b/src/main/kotlin/com/yourcompany/quickback/NavigationHistoryService.kt
@@ -1,0 +1,17 @@
+package com.yourcompany.quickback
+
+import com.intellij.openapi.vfs.VirtualFile
+
+data class NavigationPoint(
+    val file: VirtualFile,
+    val offset: Int,
+    val sourceFunctionDisplayName: String? // e.g., "function_A"
+)
+
+interface NavigationHistoryService {
+    fun setLastNavigationSource(point: NavigationPoint?)
+    fun getLastNavigationSource(): NavigationPoint?
+    fun clearLastNavigationSource() {
+        setLastNavigationSource(null)
+    }
+}

--- a/src/main/kotlin/com/yourcompany/quickback/NavigationHistoryServiceImpl.kt
+++ b/src/main/kotlin/com/yourcompany/quickback/NavigationHistoryServiceImpl.kt
@@ -1,0 +1,18 @@
+package com.yourcompany.quickback
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+
+@Service(Service.Level.PROJECT)
+class NavigationHistoryServiceImpl(private val project: Project) : NavigationHistoryService {
+    @Volatile
+    private var lastPoint: NavigationPoint? = null
+
+    override fun setLastNavigationSource(point: NavigationPoint?) {
+        lastPoint = point
+    }
+
+    override fun getLastNavigationSource(): NavigationPoint? {
+        return lastPoint
+    }
+}

--- a/src/main/kotlin/com/yourcompany/quickback/QuickBackLineMarkerProvider.kt
+++ b/src/main/kotlin/com/yourcompany/quickback/QuickBackLineMarkerProvider.kt
@@ -1,0 +1,106 @@
+package com.yourcompany.quickback
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNameIdentifierOwner
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.vfs.VirtualFile
+
+class QuickBackLineMarkerProvider : LineMarkerProvider {
+
+    companion object {
+        private val LOG = Logger.getInstance(QuickBackLineMarkerProvider::class.java)
+    }
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        val project = element.project
+        val historyService = project.service<NavigationHistoryService>()
+        val backStateCleaner = project.service<BackStateCleaner>()
+        val currentFileOfElement = element.containingFile?.virtualFile
+
+        val lastNavSource = historyService.getLastNavigationSource()
+        if (lastNavSource == null) {
+            // If there's no source, but this file was marked as having the icon, clear that mark.
+            if (currentFileOfElement != null && currentFileOfElement == backStateCleaner.currentTargetFileWithBackIcon) {
+                LOG.debug("No lastNavSource, clearing currentTargetFileWithBackIcon for ${currentFileOfElement.name}")
+                backStateCleaner.currentTargetFileWithBackIcon = null
+            }
+            return null
+        }
+
+        // We want to show the icon on the element we just navigated TO.
+        // This element should be a named declaration (like a function or class name).
+        // The `element` parameter is iterated over by IntelliJ for all PSI elements in view.
+        // We need to identify if `element` is the *target* of our last navigation.
+
+        val currentEditor = FileEditorManager.getInstance(project).selectedTextEditor ?: return null
+        val currentPsiFile = PsiDocumentManager.getInstance(project).getPsiFile(currentEditor.document) ?: return null
+        val currentVirtualFile = currentPsiFile.virtualFile ?: return null
+
+        // Don't show icon if we are still in the source file of navigation, unless it's a different offset (self-navigation)
+        if (currentVirtualFile == lastNavSource.file && element.textRange.contains(lastNavSource.offset)) {
+            // This condition means we are likely still at the source of the navigation, or navigated to self.
+            // Only clear if we are AT the original source element to prevent premature clearing.
+            // A better check would be if the current editor's caret is at lastNavSource.offset.
+            // For now, if the "destination" is the exact same file and contains the original offset, don't show.
+            // This avoids showing "back" to the same spot if navigation didn't really go anywhere new.
+            // However, if we navigated from functionA to functionA (e.g. recursive call definition), this would hide it.
+            // Let's refine: show if current element is NOT where we came from.
+             if (currentVirtualFile == lastNavSource.file && currentEditor.caretModel.offset == lastNavSource.offset) {
+                 LOG.debug("Not showing marker: current location is the same as source navigation point.")
+                 return null
+             }
+        }
+
+        // Show the icon on the named identifier of a declaration (e.g., function name, class name).
+        // The `element` passed here is often the identifier itself.
+        if (element is PsiNameIdentifierOwner && element.nameIdentifier == element) {
+            // Check if this element's file and rough location matches the *current* editor focus,
+            // not the `lastNavSource` file. We are marking the DESTINATION.
+            if (element.containingFile.virtualFile == currentVirtualFile) {
+                 // Heuristic: If the current caret is inside this element, it's a good candidate.
+                 // This helps ensure we put the marker on the item that was actually navigated to.
+                if (element.textRange.contains(currentEditor.caretModel.offset) ||
+                    element.parent.textRange.contains(currentEditor.caretModel.offset)) { // check parent for broader scope
+
+                    LOG.debug("Showing marker for element: ${element.text} in file ${currentVirtualFile.name}")
+                    project.service<BackStateCleaner>().currentTargetFileWithBackIcon = currentVirtualFile
+
+                    return LineMarkerInfo(
+                        element, // Element to attach to (the PsiNameIdentifierOwner itself)
+                        element.textRange, // Text range to highlight (usually the element's range)
+                        BackToCallGutterIconRenderer(project, lastNavSource, element).icon, // Icon is taken from renderer
+                        null, // Tooltip provider (renderer handles it)
+                        { _, elt -> // Navigation handler (renderer handles it)
+                            val renderer = BackToCallGutterIconRenderer(project, lastNavSource, elt)
+                            // Clear target file before performing action, as action will clear history
+                            project.service<BackStateCleaner>().currentTargetFileWithBackIcon = null
+                            renderer.getClickAction()?.actionPerformed(
+                                com.intellij.openapi.actionSystem.AnActionEvent.createFromDataContext(
+                                    com.intellij.openapi.actionSystem.ActionPlaces.UNKNOWN, null
+                                ) { key -> FileEditorManager.getInstance(project).selectedTextEditor?.dataContext?.getData(key) }
+                            )
+                        },
+                        GutterIconRenderer.Alignment.LEFT // Alignment in the gutter
+                    ).apply {
+                        this.lineMarkerTooltip = BackToCallGutterIconRenderer(project, lastNavSource, element).tooltipText
+                    }
+                } else {
+                    LOG.trace("Skipping marker: element ${element.text} not at current caret position ${currentEditor.caretModel.offset}")
+                     // If this element is NOT where the caret is, but it IS in the file currently marked as target,
+                     // and this LineMarkerProvider is being called (e.g. due to a different element check or refresh),
+                     // we should NOT clear currentTargetFileWithBackIcon here.
+                     // It should only be cleared by BackStateCleaner itself or when the icon is clicked.
+                }
+            }
+        }
+        return null
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,18 +1,32 @@
-<!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
-    <id>com.github.natthphong.tarplugin</id>
-    <name>tar-plugin</name>
-    <vendor>natthphong</vendor>
+    <id>com.yourcompany.quickback</id>
+    <name>Quick Back</name>
+    <version>1.0</version>
+    <vendor email="support@yourcompany.com" url="http://www.yourcompany.com">YourCompany</vendor>
+
+    <description><![CDATA[
+    Provides a simple way to navigate back to the call site after jumping to a definition.<br>
+    <em>A small UI element appears at the definition site to take you back.</em>
+    ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
-
-    <resource-bundle>messages.MyBundle</resource-bundle>
+    <depends>com.intellij.modules.java</depends> <!-- Essential for Java/Kotlin PSI manipulation -->
 
     <extensions defaultExtensionNs="com.intellij">
-        <toolWindow factoryClass="com.github.natthphong.tarplugin.toolWindow.MyToolWindowFactory" id="MyToolWindow"/>
+        <projectService serviceImplementation="com.yourcompany.quickback.NavigationHistoryServiceImpl"
+                        serviceInterface="com.yourcompany.quickback.NavigationHistoryService"/>
+        <projectService serviceImplementation="com.yourcompany.quickback.BackStateCleaner"/>
+        <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.yourcompany.quickback.QuickBackLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="kotlin" implementationClass="com.yourcompany.quickback.QuickBackLineMarkerProvider"/>
+        <!-- Other extensions will be added here -->
     </extensions>
 
     <applicationListeners>
-        <listener class="com.github.natthphong.tarplugin.listeners.MyApplicationActivationListener" topic="com.intellij.openapi.application.ApplicationActivationListener"/>
+        <listener class="com.yourcompany.quickback.GoToDefinitionListener"
+                  topic="com.intellij.openapi.actionSystem.ex.AnActionListener"/>
     </applicationListeners>
+
+    <actions>
+        <!-- Actions will be defined here if needed -->
+    </actions>
 </idea-plugin>


### PR DESCRIPTION
Implements an IntelliJ plugin named 'Quick Back'.

Core functionality:
- After navigating from a function call to its definition, a 'Back' gutter icon appears at the destination.
- Clicking this icon navigates the user back to the original call site.

Features:
- Listens for 'Go to Definition' actions.
- Stores the source navigation point (file, offset, function name).
- Displays a gutter icon (AllIcons.Actions.Back) at the navigation target.
- Provides a tooltip for the gutter icon indicating the return location.
- Handles dismissal of the icon when:
  - The icon is clicked.
  - The file containing the icon is edited.
  - The file containing the icon is closed.
  - The user navigates away from the file containing the icon.
- Allows the 'Back' icon to be shown in library code if navigated to from project code.
- Uses project-level services for state management and listeners for event handling.
- Includes logging for easier debugging.